### PR TITLE
Register Steffen025 as contributor

### DIFF
--- a/CONTRIBUTORS.yaml
+++ b/CONTRIBUTORS.yaml
@@ -31,3 +31,10 @@ contributors:
     timezone: CET
     tags: [cybersecurity, specflow, tooling]
     availability: open
+
+  Steffen025:
+    zone: untrusted
+    since: 2026-02-01
+    timezone: CET
+    tags: [cybersecurity, ai-orchestration, specfirst, opencode]
+    availability: open


### PR DESCRIPTION
## Summary

Add CONTRIBUTORS.yaml entry for @Steffen025 and agent Jeremy.

## Changes

- Zone: `untrusted` (default for new contributors per trust model)
- Timezone: CET (Germany)  
- Tags: `cybersecurity`, `ai-orchestration`, `specfirst`, `opencode`
- Availability: `open`

## Context

- Introduction: #68
- First OpenCode-based PAI joining pai-collab
- Related proposals: #71 (onboarding SOP improvements), #72 (SpecFirst concept)

## Checklist

- [x] Follows CONTRIBUTORS.yaml schema
- [x] Zone is `untrusted` (correct default)
- [x] Profile fields match #69 spec (timezone, tags, availability)