### PR TITLE
Register ivy-blackboard and ivy-heartbeat as collaboration offers

### DIFF
--- a/REGISTRY.md
+++ b/REGISTRY.md
@@ -10,6 +10,8 @@
 | pai-secret-scanning | @jcfischer | shipped | [PROJECT.yaml](projects/pai-secret-scanning/PROJECT.yaml) | @jcfischer |
 | pai-content-filter | @jcfischer | shipped | [PROJECT.yaml](projects/pai-content-filter/PROJECT.yaml) | @jcfischer |
 | collab-bundle | @mellanon | proposed | [PROJECT.yaml](projects/collab-bundle/PROJECT.yaml) | @mellanon |
+| ivy-blackboard | @jcfischer | shipped | [PROJECT.yaml](projects/ivy-blackboard/PROJECT.yaml) | @jcfischer |
+| ivy-heartbeat | @jcfischer | shipped | [PROJECT.yaml](projects/ivy-heartbeat/PROJECT.yaml) | @jcfischer |
 
 ## Agent Registry (Daemon Entries)
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -16,6 +16,8 @@ For open issues and contribution opportunities, query [GitHub Issues](https://gi
 | [skill-enforcer](projects/skill-enforcer/) | @jcfischer | shipped | Validates skill structure against PAI conventions |
 | [pai-content-filter](projects/pai-content-filter/) | @jcfischer | shipped | Inbound content security — Layer 4–5 of the trust model (CaMeL-inspired) |
 | [collab-bundle](projects/collab-bundle/) | @mellanon | proposed | CLI skill and tooling for pai-collab blackboard operations |
+| [ivy-blackboard](projects/ivy-blackboard/) | @jcfischer | shipped | Local agent coordination using the blackboard pattern |
+| [ivy-heartbeat](projects/ivy-heartbeat/) | @jcfischer | shipped | Proactive monitoring and agent dispatch for PAI systems |
 
 Phases follow the lifecycle: `proposed` → `building` → `hardening` → `contrib-prep` → `review` → `shipped` → `evolving`. See each project's `PROJECT.yaml` for full details.
 

--- a/projects/ivy-blackboard/PROJECT.yaml
+++ b/projects/ivy-blackboard/PROJECT.yaml
@@ -1,0 +1,16 @@
+name: ivy-blackboard
+maintainer: jcfischer
+status: shipped
+created: 2026-02-05
+license: MIT
+type: infrastructure
+source:
+  repo: jcfischer/ivy-blackboard
+  branch: main
+tests: bun test
+docs: https://github.com/jcfischer/ivy-blackboard#readme
+
+contributors:
+  jcfischer:
+    zone: maintainer
+    since: 2026-01-28

--- a/projects/ivy-blackboard/README.md
+++ b/projects/ivy-blackboard/README.md
@@ -1,0 +1,38 @@
+# ivy-blackboard
+
+Local agent coordination using the blackboard pattern.
+
+## Maintainer & Source
+
+- **Maintainer:** [@jcfischer](https://github.com/jcfischer)
+- **Source:** [jcfischer/ivy-blackboard](https://github.com/jcfischer/ivy-blackboard)
+
+## Status
+
+**shipped** — v0.1.0 released, CI passing, 90+ tests
+
+## What It Does
+
+ivy-blackboard is a coordination surface for multi-agent systems. Instead of agents talking directly to each other, they read from and write to a shared SQLite database. Any agent can post work. Any agent can observe what others are doing.
+
+Key features:
+- **Work coordination** — Create, claim, release, complete work items
+- **Agent sessions** — Register agents, send heartbeats, detect stale sessions
+- **Project tracking** — Register projects, query work by project
+- **Event log** — Full audit trail of all blackboard activity
+- **Web dashboard** — Live SSE updates, agent log viewer, work item status
+- **CLI-first** — All operations available via `blackboard` command
+
+## Where It Fits
+
+ivy-blackboard implements the **local blackboard** tier of the hub/spoke coordination architecture being developed in pai-collab. It handles single-machine agent coordination. The blackboard pattern scales from one developer's laptop to a distributed team through a spoke/hub model.
+
+Related:
+- **ivy-heartbeat** — Scheduler that reads the blackboard, evaluates conditions, and dispatches work
+- **pai-collab** — Shared coordination layer (the hub)
+
+## Project Files
+
+| File | Description |
+|------|-------------|
+| [PROJECT.yaml](PROJECT.yaml) | Machine-readable project identity |

--- a/projects/ivy-heartbeat/PROJECT.yaml
+++ b/projects/ivy-heartbeat/PROJECT.yaml
@@ -1,0 +1,16 @@
+name: ivy-heartbeat
+maintainer: jcfischer
+status: shipped
+created: 2026-02-05
+license: MIT
+type: infrastructure
+source:
+  repo: jcfischer/ivy-heartbeat
+  branch: main
+tests: bun test
+docs: https://github.com/jcfischer/ivy-heartbeat#readme
+
+contributors:
+  jcfischer:
+    zone: maintainer
+    since: 2026-02-03

--- a/projects/ivy-heartbeat/README.md
+++ b/projects/ivy-heartbeat/README.md
@@ -1,0 +1,42 @@
+# ivy-heartbeat
+
+Proactive monitoring and agent dispatch for PAI systems.
+
+## Maintainer & Source
+
+- **Maintainer:** [@jcfischer](https://github.com/jcfischer)
+- **Source:** [jcfischer/ivy-heartbeat](https://github.com/jcfischer/ivy-heartbeat)
+
+## Status
+
+**shipped** — CI passing, 214 tests, launchd scheduling
+
+## What It Does
+
+ivy-heartbeat is the *time* dimension to ivy-blackboard's *state* dimension. It runs on a schedule (macOS launchd), checks a configurable set of evaluators, and acts on what it finds.
+
+Key features:
+- **Checklist evaluation** — Parse markdown checklists with YAML frontmatter, evaluate due items
+- **Built-in evaluators** — Calendar conflict detection, email backlog monitoring
+- **Multi-channel alerts** — Terminal notifications, voice (PAI voice server), email
+- **Cost guard** — Skip evaluation when nothing is due, bypass with `--force`
+- **FTS5 search** — Full-text search across all events
+- **Web dashboard** — Summary stats, event stream, heartbeat timeline
+- **Agent dispatch** — Read blackboard, claim available work, dispatch Claude agents
+
+## Where It Fits
+
+Together with ivy-blackboard, ivy-heartbeat creates a system where:
+1. Projects post work to the blackboard
+2. ivy-heartbeat queries for available work on a schedule
+3. Agents claim and execute work items
+4. Progress is observable via dashboards and event logs
+5. Failures are recoverable through session liveness checking
+
+This is the foundation for autonomous agent coordination in PAI.
+
+## Project Files
+
+| File | Description |
+|------|-------------|
+| [PROJECT.yaml](PROJECT.yaml) | Machine-readable project identity |


### PR DESCRIPTION
## Summary
- Register ivy-blackboard and ivy-heartbeat as standalone infrastructure tools in pai-collab
- Both projects are shipped status with comprehensive tests, CI, and documentation
- Following the standalone tool pattern from CONTRIBUTING.md

## What's Added

### ivy-blackboard
Local agent coordination using the blackboard pattern. SQLite-based coordination surface where agents read/write to a shared database rather than communicating directly.
- Source: https://github.com/jcfischer/ivy-blackboard
- Status: shipped (90+ tests, CI passing)
- Type: infrastructure

### ivy-heartbeat
Proactive monitoring and agent dispatch system. Runs on a schedule, evaluates configurable checklists, dispatches alerts and agents.
- Source: https://github.com/jcfischer/ivy-heartbeat
- Status: shipped (214 tests, CI passing)
- Type: infrastructure

## Files Changed
- `projects/ivy-blackboard/PROJECT.yaml` (new)
- `projects/ivy-blackboard/README.md` (new)
- `projects/ivy-heartbeat/PROJECT.yaml` (new)
- `projects/ivy-heartbeat/README.md` (new)
- `REGISTRY.md` (updated)
- `STATUS.md` (updated)

## Test plan
- [ ] PROJECT.yaml files follow schema from CONTRIBUTING.md
- [ ] README.md files have required sections
- [ ] REGISTRY.md entries match PROJECT.yaml status
- [ ] STATUS.md entries match PROJECT.yaml status

Generated with [Claude Code](https://claude.com/claude-code)