### PR TITLE
register: pai-review-mode — Platform-Agnostic Review Mode

### DIFF
--- a/projects/pai-review-mode/JOURNAL.md
+++ b/projects/pai-review-mode/JOURNAL.md
@@ -1,0 +1,49 @@
+# pai-review-mode — Journey Log
+
+A structured, append-only log of what happened on this project. New entries go at the top. Each entry is a self-contained block — submit via PR, no merge conflicts.
+
+**Maintainer:** @Steffen025
+
+---
+
+## 2026-02-17 — Relocated to standalone repository
+
+**Author:** @Steffen025 (agent: Jeremy)
+**Phase:** Release
+**Status:** Code relocated from pai-collab contributions/ to Steffen025/pai-review-mode per blackboard architecture pattern.
+
+### What Happened
+- Created standalone repository: [Steffen025/pai-review-mode](https://github.com/Steffen025/pai-review-mode)
+- Relocated 39 source files, 364 tests from `contributions/review-mode/` in pai-collab PR #102
+- Updated package.json with new repository URL
+- Registered project on pai-collab blackboard (this PR)
+- Set up Ed25519 SSH commit signing per governance requirements
+
+### What Emerged
+- pai-collab's "code lives in your own repo, blackboard tracks coordination" pattern is clean — separates code ownership from community coordination
+- The architecture redirect from @mellanon on PR #102 was the right call
+- Review Mode is now independently releasable with its own CI, versioning, and contributor model
+
+---
+
+## 2026-02-09 — Initial implementation complete
+
+**Author:** @Steffen025 (agent: Jeremy)
+**Phase:** Build
+**Status:** 364 tests passing, 89.26% coverage, all 40 ISC criteria passed.
+**Issues:** pai-collab #17
+
+### What Happened
+- Developed Platform-Agnostic Review Mode as response to CaMeL framework gaps
+- Core components: HMAC-SHA256 TypedReferences, hook-enforced tool allowlist, quarantine agent spawning
+- Platform adapters for OpenCode (throw Error) and Claude Code (exit 2)
+- Comprehensive test suite: 123 unit + 165 integration + 85 adversarial + 11 benchmark
+- Performance: HMAC 0.02ms (2,500x under target), hook enforcement 0.01ms (1,000x under target)
+- Originally submitted as pai-collab PR #102
+
+### What Emerged
+- True Dual-Context is fundamentally stronger than taint tracking — simpler to audit, clearer security boundary
+- Allowlist-over-denylist (ADR-003) is the right default for security-critical tool restrictions
+- HMAC-SHA256 performance makes symmetric signatures the clear choice over asymmetric for session-scoped references
+
+---

--- a/projects/pai-review-mode/PROJECT.yaml
+++ b/projects/pai-review-mode/PROJECT.yaml
@@ -1,0 +1,15 @@
+name: pai-review-mode
+maintainer: Steffen025
+status: alpha
+created: 2026-02-09
+license: MIT
+type: infrastructure
+source:
+  repo: Steffen025/pai-review-mode
+  branch: main
+tests: bun test
+
+contributors:
+  Steffen025:
+    zone: maintainer
+    since: 2026-02-09

--- a/projects/pai-review-mode/README.md
+++ b/projects/pai-review-mode/README.md
@@ -1,0 +1,50 @@
+# pai-review-mode
+
+Platform-Agnostic Review Mode for PAI agents — True Dual-Context isolation for safely processing untrusted code contributions.
+
+**Source:** [github.com/Steffen025/pai-review-mode](https://github.com/Steffen025/pai-review-mode)
+
+## What It Does
+
+Security framework for AI coding agents that need to safely analyze untrusted code (pull requests, external repos, user-submitted code). Prevents prompt injection attacks through True Dual-Context isolation — the main agent never sees raw untrusted content.
+
+1. **True Dual-Context Isolation**: Separate agent contexts for trusted and untrusted content. Main agent spawns quarantine agents via Task tool — never reads untrusted files directly.
+2. **HMAC-SHA256 TypedReferences**: Cryptographically signed URIs that prove file access was explicitly authorized by the trusted main agent. Includes expiration (TTL), session binding, and path canonicalization.
+3. **Hook-Enforced Tool Allowlist**: Quarantine agents can ONLY use Read, Grep, Glob (23 tools blocked). Enforced via platform hooks on every tool call — not prompt-based restrictions.
+4. **Platform-Agnostic Adapters**: Works on OpenCode (`throw Error()`) and Claude Code (`process.exit(2)`). ~30 lines per adapter, 268+ lines of shared enforcement logic.
+
+## Stats
+
+- 364 tests (123 unit + 165 integration + 85 adversarial + 11 benchmark)
+- 89.26% line coverage
+- 8 adversarial attack scenarios (AS-001 through AS-008)
+- HMAC generation: 0.02ms avg (2,500x under 50ms target)
+- Hook enforcement: 0.01ms p99 (1,000x under 10ms target)
+- 4 ADRs documenting architectural decisions
+
+## Security Properties
+
+Addresses 7 identified gaps in the CaMeL framework (DeepMind, 2025):
+
+| Gap | CaMeL Limitation | Review Mode Solution |
+|-----|-------------------|---------------------|
+| C-1 | No systematic content sanitization | TypedReference URI format with HMAC integrity |
+| C-2 | No trusted/untrusted context separation | True Dual-Context via agent spawning |
+| C-3 | No runtime tool restriction enforcement | Hook-based allowlist enforcement |
+| H-1 | No hook-based enforcement mechanism | Platform adapters (OpenCode, Claude Code) |
+| H-2 | No rate limiting | Sliding window (100/min per agent, 5 concurrent) |
+| H-3 | No audit logging | Buffered JSONL with sensitive data redaction |
+| H-4 | No timeout enforcement | Configurable limits (default: 5 min) |
+
+## Relationship to pai-content-filter
+
+Together these form a complete security perimeter:
+- **pai-content-filter** (inbound) — prevents malicious content from compromising agents reading shared repos
+- **pai-review-mode** (review) — safely reviews untrusted code contributions without exposing the main agent to prompt injection
+
+Review Mode can use pai-content-filter as an additional defense layer within the quarantine context.
+
+## Research Basis
+
+- [CaMeL: Defeating Prompt Injections by Design](https://arxiv.org/abs/2503.18813) (DeepMind, 2025) — architectural inspiration; Review Mode addresses 7 gaps identified in adversarial analysis
+- Adversarial security review of pai-content-filter (PR #90, merged) informed the defense-in-depth approach


### PR DESCRIPTION
## Registration: pai-review-mode

Registers **pai-review-mode** as a standalone tool on the blackboard, following the architecture pattern outlined by @mellanon in [PR #102 comment](https://github.com/mellanon/pai-collab/pull/102#issuecomment-2714024305).

### Source Repository

**[Steffen025/pai-review-mode](https://github.com/Steffen025/pai-review-mode)**

### What It Does

Platform-Agnostic Review Mode for PAI agents — True Dual-Context isolation for safely processing untrusted code contributions. Addresses 7 identified gaps in the CaMeL framework (DeepMind, 2025).

**Core capabilities:**
- HMAC-SHA256 TypedReferences for cryptographic file access authorization
- Hook-enforced tool allowlist (Read, Grep, Glob only — 23 tools blocked)
- Platform adapters for OpenCode (`throw Error()`) and Claude Code (`process.exit(2)`)
- Rate limiting (100/min per agent, 5 concurrent max)
- Buffered JSONL audit logging with sensitive data redaction

### Stats

- 364 tests (123 unit + 165 integration + 85 adversarial + 11 benchmark)
- 89.26% line coverage
- HMAC generation: 0.02ms avg
- Hook enforcement: 0.01ms p99

### History

Originally developed as `contributions/review-mode/` in PR #102. Relocated to standalone repository per the blackboard architecture pattern: code lives in contributor repos, blackboard tracks coordination.

### Blackboard Artifacts

- `projects/pai-review-mode/README.md` — Project overview
- `projects/pai-review-mode/PROJECT.yaml` — Source pointer to `Steffen025/pai-review-mode`
- `projects/pai-review-mode/JOURNAL.md` — Initial journal entries

### Relationship to Ecosystem

- Complements **pai-content-filter** (inbound defense) with review-time isolation
- Informed by adversarial reviews: PRs #90 (content-filter), #99 (Hive protocol), #100 (ivy), #101 (trust model) — all merged
- Addresses pai-collab Issue #17 (review mode tool restrictions)